### PR TITLE
Inicializacion de variable en test [Depuracion Warning]

### DIFF
--- a/labs/datalab/btest.c
+++ b/labs/datalab/btest.c
@@ -296,7 +296,7 @@ static int test_3_arg(funct_t f, funct_t ft,
 static int test_function(test_ptr t) {
     int test_counts[3];    /* number of test values for each arg */
     int args = t->args;    /* number of function arguments */
-    int arg_test_range[3]; /* test range for each argument */
+    int arg_test_range[3] = {0,0,0}; /* test range for each argument */
     int i, a1, a2, a3;
     int errors = 0;
 

--- a/labs/datalab/btest.c
+++ b/labs/datalab/btest.c
@@ -68,8 +68,8 @@ static int timeout_limit = TIMEOUT_LIMIT; /* -T */
 static char* test_fname = NULL;
 
 /* Special case when only use fixed argument(s) (-1, -2, or -3) */
-static int has_arg[3] = {0,0,0};
-static unsigned argval[3] = {0,0,0};
+static int has_arg[3] = {0};
+static unsigned argval[3] = {0};
 
 /* Use fixed weight for rating, and if so, what should it  be? (-r) */
 static int global_rating = 0;
@@ -296,7 +296,7 @@ static int test_3_arg(funct_t f, funct_t ft,
 static int test_function(test_ptr t) {
     int test_counts[3];    /* number of test values for each arg */
     int args = t->args;    /* number of function arguments */
-    int arg_test_range[3] = {0,0,0}; /* test range for each argument */
+    int arg_test_range[3] = {0}; /* test range for each argument */
     int i, a1, a2, a3;
     int errors = 0;
 


### PR DESCRIPTION
Inicializo la variable arg_test_range[] en 0 para depurar el warning a la hora de hacer  `make grade`


**Antes Del Cambio :** 
![image](https://user-images.githubusercontent.com/38387367/117704026-be44dd80-b1a0-11eb-9568-122f93d3ebc0.png)

**Despues del cambio**

![image](https://user-images.githubusercontent.com/38387367/117704219-f9dfa780-b1a0-11eb-80d3-b6b2ab04aca9.png)

